### PR TITLE
Solves issue #6

### DIFF
--- a/feed_venn_labels.pl
+++ b/feed_venn_labels.pl
@@ -1,0 +1,89 @@
+#!/usr/bin/perl -w
+use strict;
+
+my $total = {};
+my $names = [];
+my $elements = [];
+while (@ARGV){
+  my $file = shift @ARGV;
+  if (-e $file){
+    open (IN, $file);
+    my @l = <IN>;
+    close IN;
+    my $h = shift @l;
+    chomp($h);
+    push @$names, $h;
+    my $tmp = {};
+    foreach my $g (@l){
+      chomp($g);
+      next unless ($g =~ /[\w\d]/);
+      $tmp->{$g} = 1;
+      $total->{$g} = 1;
+    }
+    push @$elements, $tmp;
+  }
+  else{
+    warn("Cannot find $file\n");
+    
+  }
+}
+
+my $ngroups = scalar(@$elements);
+my $nels = 1 << $ngroups;
+
+my $result = [];
+my $numbers = [];
+my $labels = [];
+
+#print "=== Group analysis ===\n";
+
+for (1 .. $nels - 1){
+  my $d = toBin($_, $ngroups);
+  my $group_elements = {};
+  foreach my $g (keys %$total){
+    my $addme = 1;
+    my $c = 0;
+    foreach my $b (@$d){
+      my $isingroup = exists($elements->[$c]{$g});
+      my $correct = !($isingroup ^ $b);
+      $addme = 0 unless ($correct);
+      $c++;
+    }
+    if ($addme){
+      $group_elements->{$g} = 1;
+    }
+  }
+  push @$result, $group_elements;
+  push @$numbers, scalar(keys %$group_elements);
+  push @$labels, join(", ", keys %$group_elements);
+  #print join('-', @$d); print "\t"; print scalar(keys %$group_elements) . "\n";
+  #print join(', ', keys %$group_elements); print "\n";
+}
+
+#print "=== nVenn input ===\n";
+print "nVenn v1.2\n";
+print "$ngroups\n";
+print join("\n", @$names) . "\n";
+print "0\n";
+for my $i (0 .. $nels-2) {
+  print "@$numbers[$i]  @$labels[$i] \n"
+}
+
+sub toBin{
+  my $n = shift;
+  my $ngroups = shift;
+  my $result = [];
+  for (1 .. $ngroups){
+    my $t = $n & 1;
+    unshift @$result, $t;
+    $n = $n >> 1;
+  }
+  return $result;
+}
+
+
+
+__DATA__
+Cancer	E-cadherin	GZMA	ITGA1	MYCN	MYO5A	MYO5B	NF2	P2RY8	PML	PPTN11	PRDM1	PRF1	RAS	SET	SMAD4	USP12		
+Ageing	ALDH2	ATM	DCLRE1	EEF1A1	GAPDH	GSK3A	IFG2R	IGF1R 	ITGA1	MIF	NEIL1	NLN	RMI2	TERF2	XRCC5	XRCC6		
+Immunity	APOBEC1	APOBEC3	CASP12	CATH	CHIA	CMA1	CTSG	gallinacinas	GZMB	GZMG	GZMH	IFN	IFTM10	IFTM5	MEP1A	NLRP	PRF1	TLRs

--- a/main.cpp
+++ b/main.cpp
@@ -77,10 +77,25 @@ borderLine getFileInfo(string fname, string outputFile){
     }
     int n = twoPow(number);
     for (i = 0; i < n; i++){
-        getline(vFile, header, ' '); /// get the number
-        weights.insert (weights.end(), atoi(header.c_str()));
-        getline(vFile, header) ;  ///  get the rest of the line with the labels
-        labels.insert (labels.end(), header);
+        getline(vFile, header); //  get the whole line
+        string w = header.substr(0,header.find_first_of(" "));
+        weights.insert (weights.end(), atoi(w.c_str())); // it take the first number
+        string label;
+        try
+        {
+            label = header.substr(header.find_first_of(" "));
+        }
+        catch (const std::exception& e)
+        {
+            cout << i << endl;
+            label = "";
+        }
+        labels.insert (labels.end(), label);
+        cout << "w=" << w << "  label:" << label << endl;
+        //getline(vFile, header, ' '); /// get the number
+        //weights.insert (weights.end(), atoi(header.c_str()));
+        //getline(vFile, header) ;  ///  get the rest of the line with the labels
+        //labels.insert (labels.end(), header);
         temp = toBin(i, number);
         printv(temp);
         cout << ".- " << weights[i] << " : " << labels[i] << endl;

--- a/main.cpp
+++ b/main.cpp
@@ -62,6 +62,7 @@ borderLine getFileInfo(string fname, string outputFile){
     vector<string> groupNames;
     vector<int> temp;
     vector<float> weights;
+    vector<string> labels;
     int i;
     vFile.open(fname.c_str());
     getline(vFile, header);
@@ -76,16 +77,18 @@ borderLine getFileInfo(string fname, string outputFile){
     }
     int n = twoPow(number);
     for (i = 0; i < n; i++){
-        getline(vFile, header);
+        getline(vFile, header, ' '); /// get the number
         weights.insert (weights.end(), atoi(header.c_str()));
+        getline(vFile, header) ;  ///  get the rest of the line with the labels
+        labels.insert (labels.end(), header);
         temp = toBin(i, number);
         printv(temp);
-        cout << ".- " << weights[i] << endl;
+        cout << ".- " << weights[i] << " : " << labels[i] << endl;
     }
     vFile.close();
     binMap mymap(number);
     string dataFile = outputFile + ".data";
-    borderLine lines(&mymap, groupNames, weights, fname, outputFile);
+    borderLine lines(&mymap, groupNames, weights, labels, fname, outputFile);
 
     vFile.open(dataFile.c_str());
     if (vFile.good() == true){ // Unfinished

--- a/topol.h
+++ b/topol.h
@@ -735,6 +735,7 @@ class borderLine
     lCounter keepDistCounter;
     vector<float> circRadii;
     vector<float> w;
+    vector<string> labels;
     vector<float> origw;
     vector<rgb> colors;
     vector<string> svgcolors;
@@ -924,7 +925,7 @@ class borderLine
 
     }
 
-    void setCircles(binMap b, vector<float> o)
+    void setCircles(binMap b, vector<float> o, vector<string> tlabels)
     {
         UINT i, j;
         int n;
@@ -952,6 +953,7 @@ class borderLine
                 circRadii.insert(circRadii.end(), 2 * sqrt(origw[n] / maxw));
                 cpoint.orig = o[n];
                 circles.insert(circles.end(), cpoint);
+                labels.insert(labels.end(), tlabels[n]);
             }
         }
         for (j = 1; j < circRadii.size(); j++){
@@ -1876,7 +1878,7 @@ class borderLine
 
 public:
     borderLine(){}
-    borderLine(binMap* b, vector<string> g, vector<float> tw, string inputFile = "venn.txt", string outputFile = "result.svg")
+    borderLine(binMap* b, vector<string> g, vector<float> tw, vector<string> tlabels, string inputFile = "venn.txt", string outputFile = "result.svg") /// aqui
     {
         UINT i;
         bm = b;
@@ -1913,7 +1915,7 @@ public:
 
 
         //init circles
-        setCircles(*bm, origw);
+        setCircles(*bm, origw, tlabels);
 
         totalExpectedSurface = 0;
         for (i = 0; i < w.size(); i++){
@@ -2140,10 +2142,18 @@ public:
       svg.addLine("	   fill: none;");
       svg.addLine("    pointer-events: all;");
       svg.addLine("  }");
-      svg.addLine("  .nLabel {");
+      svg.addLine("  .tLabel {");
       svg.addLine("	   font-family: Arial;");
       svg.addLine("    pointer-events: none;");
       char t[200];
+      sprintf(t, "	   font-size: %dpx;", fsize+4);
+      svg.addLine((string) t);
+      svg.addLine("	   text-anchor: middle;");
+      svg.addLine("	   alignment-baseline: central;");
+      svg.addLine("  }");
+      svg.addLine("  .nLabel {");
+      svg.addLine("	   font-family: Arial;");
+      svg.addLine("    pointer-events: none;");
       sprintf(t, "	   font-size: %dpx;", fsize);
       svg.addLine((string) t);
       svg.addLine("	   text-anchor: middle;");
@@ -2226,6 +2236,10 @@ public:
             sprintf(temp, "<circle onclick=\"fromCircle(%u)\" class=\"circle\" cx=\"%.4f\" cy=\"%.4f\" r=\"%.4f\" />", circles[i].n, svgtemp.x,
                             svgtemp.y, svgtemp.radius);
             tst = temp;
+            svg.addLine(tst);
+            char addLabel[500];
+            sprintf(addLabel, "<text class=\"tLabel\" x=\"%.2f\" y=\"%.2f\">%s</text>", svgtemp.x, svgtemp.y - 4*fsize/2, labels[i].c_str());
+            tst =  addLabel;
             svg.addLine(tst);
             char addNum[200];
             sprintf(addNum, "<text class=\"nLabel\" x=\"%.2f\" y=\"%.2f\">%g</text>", svgtemp.x, svgtemp.y - fsize/2, circles[i].orig);


### PR DESCRIPTION
A new perl script named "feed_venn_labels.pl" has been created that generates an ascii input file with the same format as before with the following modification:
The lines indicating the number of elements for each group can hold in addition a label for that circle. A blank space separates the number and the label (which continues until the end of the line).
So these two files would be for equivalent diagrams, except that the second one contains labels:

=============
nVenn v1.2
3
Group1
Group2
Group3
0
2
1
2
3
0
1
1
=============
nVenn v1.2
3
Group1
Group2
Group3
0
2  z, x 
1  f 
2  g, h 
3  c, d, e 
0   
1  b 
1  a 
==============

The main.cpp has modified in order to parse correctly both types of input files. In addition the class borderLine has been extended to include a vector of strings containing the labels for each circle. The printing of these labels to the svg plot has been added in function toSVG().
The most tricky part has been to properly assign the labels to the corresponding circle, as the binMap does not follow "standard binary order". This assignment has been done inside the function setCircles(...).

The documentation has not been updated for this change, as it is unsure if this modification will be included into the main branch.